### PR TITLE
Lazy load headers so we can still set delimiter / enclosure

### DIFF
--- a/lib/EasyCSV/Reader.php
+++ b/lib/EasyCSV/Reader.php
@@ -7,22 +7,24 @@ class Reader extends AbstractBase
     private $headersInFirstRow = true;
     private $headers;
     private $line;
+    private $init;
 
     public function __construct($path, $mode = 'r+', $headersInFirstRow = true)
     {
         parent::__construct($path, $mode);
         $this->headersInFirstRow = $headersInFirstRow;
-        $this->headers = $this->headersInFirstRow === true ? $this->getRow() : false;
-        $this->line    = 0;
+        $this->line = 0;
     }
 
     public function getHeaders()
     {
+        $this->init();
         return $this->headers;
     }
-
+    
     public function getRow()
     {
+        $this->init();
         if (($row = fgetcsv($this->handle, 1000, $this->delimiter, $this->enclosure)) !== false) {
             $this->line++;
             return $this->headers ? array_combine($this->headers, $row) : $row;
@@ -43,5 +45,14 @@ class Reader extends AbstractBase
     public function getLineNumber()
     {
         return $this->line;
+    }
+    
+    protected function init()
+    {
+        if (true === $this->init) {
+            return;
+        }
+        $this->init    = true;
+        $this->headers = $this->headersInFirstRow === true ? $this->getRow() : false;
     }
 }

--- a/tests/EasyCSV/Tests/ReaderTest.php
+++ b/tests/EasyCSV/Tests/ReaderTest.php
@@ -2,30 +2,44 @@
 
 namespace EasyCSV\Tests;
 
+use EasyCSV\Reader;
+
 class ReaderTest extends \PHPUnit_Framework_TestCase
 {
-    private $reader;
-
-    public function setUp()
+    /**
+     * @dataProvider getReaders
+     */
+    public function testOneAtAtime(Reader $reader)
     {
-        $this->reader = new \EasyCSV\Reader(__DIR__ . '/read.csv');
-    }
-
-    public function testOneAtAtime()
-    {
-        while($row = $this->reader->getRow()) {
+        while($row = $reader->getRow()) {
             $this->assertTrue(is_array($row));
             $this->assertEquals(3, count($row));
         }
     }
 
-    public function testGetAll()
+    /**
+     * @dataProvider getReaders
+     */
+    public function testGetAll(Reader $reader)
     {
-        $this->assertEquals(5, count($this->reader->getAll()));
+        $this->assertEquals(5, count($reader->getAll()));
     }
 
-    public function testGetHeaders()
+    /**
+     * @dataProvider getReaders
+     */
+    public function testGetHeaders(Reader $reader)
     {
-        $this->assertEquals(array("column1", "column2", "column3"), $this->reader->getHeaders());
+        $this->assertEquals(array("column1", "column2", "column3"), $reader->getHeaders());
+    }
+    
+    public function getReaders()
+    {
+        $readerSemiColon = new \EasyCSV\Reader(__DIR__ . '/read_sc.csv');
+        $readerSemiColon->setDelimiter(';');
+        return array(
+            array(new \EasyCSV\Reader(__DIR__ . '/read.csv')),
+            array($readerSemiColon),
+        );
     }
 }

--- a/tests/EasyCSV/Tests/read_sc.csv
+++ b/tests/EasyCSV/Tests/read_sc.csv
@@ -1,0 +1,6 @@
+"column1"; "column2"; "column3"
+"1column2value"; "1column3value"; "1column4value"
+"2column2value"; "2column3value"; "2column4value"
+"3column2value"; "3column3value"; "3column4value"
+"4column2value"; "4column3value"; "4column4value"
+"5column2value"; "5column3value"; "5column4value"


### PR DESCRIPTION
A CSV with headers and not using comma as delimiter or not using '"' as enclosure couldn't be parsed since the headers were parsed in the constructor, which is ofcourse before a  EasyCSV\AbstractBase::setDelimiter or EasyCSV\AbstractBase::setEnclosure call

Fixed this by lazy loading the headers.
