### PR TITLE
Sometimes when we pass to the writer 'php://temp'

### DIFF
--- a/lib/EasyCSV/AbstractBase.php
+++ b/lib/EasyCSV/AbstractBase.php
@@ -32,4 +32,9 @@ abstract class AbstractBase
     {
         $this->enclosure = $enclosure;
     }
+    
+    public function getHandle()
+    {
+        return $this->handle;
+    }
 }


### PR DESCRIPTION
or memory, and get the file contents we need to get the handle.

Eg: 

```
$writer = new \EasyCSV\Writer('php://temp');
$writer->writeRow(array('column1', 'column2', 'column3'));
$writer->writeFromArray(array(
    'value1, value2, value3',
    '2' => array('test1' => 'value1 dd', 'test2' => 'value2 ff', 'test3' => 'value3 gg')
));
rewind($writer->getHandle());
echo stream_get_contents($writer->getHandle());
```
