### PR TITLE
allow for more flexibility on first line (headers)

### DIFF
--- a/lib/EasyCSV/Reader.php
+++ b/lib/EasyCSV/Reader.php
@@ -59,4 +59,9 @@ class Reader extends AbstractBase
         $this->init    = true;
         $this->headers = $this->headersInFirstRow === true ? $this->getRow() : false;
     }
+
+    protected function incrementLine()
+    {
+        $this->line++;
+    }
 }


### PR DESCRIPTION
there are cases where we have a first line like:

```
A, B, C
1, 2, 3
```

as opposed to:

```
A,B,C
1, 2, 3
```

or

```
A,B,C
1,2,3
```

support such that we trim spaces between delimiters and start of the string

actually now that i looked the values, for the values too

not sure if this flexibility can violate some rules for csv's, what do you think?
