### PR TITLE
Discovered SplFileObject::fgetcsv() bugs implemented a workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,12 @@ php:
   - 5.5
   - 5.6
   - hhvm
+  - 7.0
 
 before_script: composer install
+
+matrix:
+  allow_failures:
+    - php: hhvm
+    - php: 7.0
+  fast_finish: true

--- a/README.markdown
+++ b/README.markdown
@@ -33,6 +33,23 @@ Or you can get everything all at once:
 print_r($reader->getAll());
 ```
 
+If you have a file with the header in a different line:
+
+```php
+// our headers aren't on the first line
+$reader = new \EasyCSV\Reader('read.csv', 'r+', false);
+// zero-based index, so this is line 4
+$reader->setHeaderLine(3);
+```
+
+Advance to a different line:
+
+```
+$reader->advanceTo(6);
+```
+
+More in the Reader unit test.
+
 ## Writer
 
 To write CSV files we need to instantiate the EasyCSV writer class:

--- a/lib/EasyCSV/AbstractBase.php
+++ b/lib/EasyCSV/AbstractBase.php
@@ -10,7 +10,7 @@ abstract class AbstractBase
 
     public function __construct($path, $mode = 'r+')
     {
-        if ( ! file_exists($path)) {
+        if (! file_exists($path)) {
             touch($path);
         }
         $this->handle = new \SplFileObject($path, $mode);

--- a/tests/EasyCSV/Tests/ReaderTest.php
+++ b/tests/EasyCSV/Tests/ReaderTest.php
@@ -6,38 +6,57 @@ use EasyCSV\Reader;
 
 class ReaderTest extends \PHPUnit_Framework_TestCase
 {
-    protected $headerValues = array( "column1", "column2", "column3" );
-    protected $expectedRows = array (
+    protected $headers = array("column1", "column2", "column3");
+
+    protected $expectedRows = array(
         0 =>
-            array (
+            array(
                 'column1' => '1column2value',
                 'column2' => '1column3value',
                 'column3' => '1column4value',
             ),
         1 =>
-            array (
+            array(
                 'column1' => '2column2value',
                 'column2' => '2column3value',
                 'column3' => '2column4value',
             ),
         2 =>
-            array (
+            array(
                 'column1' => '3column2value',
                 'column2' => '3column3value',
                 'column3' => '3column4value',
             ),
         3 =>
-            array (
+            array(
                 'column1' => '4column2value',
                 'column2' => '4column3value',
                 'column3' => '4column4value',
             ),
         4 =>
-            array (
+            array(
                 'column1' => '5column2value',
                 'column2' => '5column3value',
                 'column3' => '5column4value',
             ),
+    );
+
+    protected $dataRow1 = array(
+        'column1' => '1column2value',
+        'column2' => '1column3value',
+        'column3' => '1column4value',
+    );
+
+    protected $dataRow2 = array(
+        'column1' => '2column2value',
+        'column2' => '2column3value',
+        'column3' => '2column4value',
+    );
+
+    protected $dataRow5 = array(
+        'column1' => '5column2value',
+        'column2' => '5column3value',
+        'column3' => '5column4value',
     );
 
     /**
@@ -54,6 +73,38 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getReaders
      */
+    public function testLastRowIsCorrect(Reader $reader)
+    {
+        $reader->getRow();
+        $reader->getRow();
+        $reader->getRow();
+        $reader->getRow();
+        $row = $reader->getRow();
+
+        $expected = $this->dataRow5;
+
+        $this->assertEquals($expected, $row);
+
+        // line number should have not advanced
+        $this->assertEquals(5, $reader->getLineNumber());
+    }
+
+    /**
+     * @dataProvider getReaders
+     */
+    public function testIsEofReturnsCorrectly(Reader $reader)
+    {
+        $this->assertFalse($reader->isEof());
+
+        $reader->getAll();
+
+        $this->assertTrue($reader->isEof());
+        $this->assertFalse($reader->getRow());
+    }
+
+    /**
+     * @dataProvider getReaders
+     */
     public function testGetAll(Reader $reader)
     {
         $this->assertEquals(5, count($reader->getAll()));
@@ -64,40 +115,43 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetHeaders(Reader $reader)
     {
-        $this->assertEquals( $this->headerValues, $reader->getHeaders());
+        $this->assertEquals($this->headers, $reader->getHeaders());
     }
 
     /**
      * @dataProvider getReaders
      */
-    public function testAdvanceto(Reader $reader)
+    public function testAdvanceTo(Reader $reader)
     {
-        $reader->advanceTo( 3 );
+        $this->assertEquals(0, $reader->getLineNumber());
 
-        $this->assertEquals( 3, $reader->getLineNumber() );
+        // getting a row before calling advanceTo() shouldn't affect it
+        $dataRow1 = $reader->getRow();
+        $this->assertEquals($this->dataRow1, $dataRow1);
+        $this->assertEquals(2, $reader->getLineNumber());
 
-        $reader->advanceTo( 0 );
+        $reader->advanceTo(3);
 
-        $row = array
-        (
-            'column1' => '1column2value',
-            'column2' => '1column3value',
-            'column3' => '1column4value',
-        );
+        $this->assertEquals(3, $reader->getLineNumber());
+
+        $reader->advanceTo(1);
+
+        $row = $this->dataRow1;
 
         $actualRow = $reader->getRow();
-        $this->assertEquals( $row, $actualRow );
+        $this->assertEquals($row, $actualRow);
+        $this->assertEquals(2, $reader->getLineNumber());
 
-        $reader->advanceTo( 3 );
+        $reader->advanceTo(3);
 
-        $row = array
-        (
-            'column1' => '4column2value',
-            'column2' => '4column3value',
-            'column3' => '4column4value',
+        $row = array(
+            'column1' => '3column2value',
+            'column2' => '3column3value',
+            'column3' => '3column4value',
         );
 
-        $this->assertEquals( $row, $reader->getRow() );
+        $this->assertEquals($row, $reader->getRow());
+        $this->assertEquals(4, $reader->getLineNumber());
     }
 
     /**
@@ -105,21 +159,87 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testAdvanceToNoHeadersFirstRow(Reader $reader)
     {
-        $row = array (
+        $firstMetaRow = array(
             0 => 'Some Meta Data',
+            1 => '',
+            2 => '',
+        );
+        $secondMetaRow = array(
+            0 => "Field: Value",
             1 => '',
             2 => '',
         );
 
         $actualRow = $reader->getRow();
-        $this->assertEquals( $row, $actualRow );
+        $this->assertEquals($firstMetaRow, $actualRow);
+        $this->assertEquals(1, $reader->getLineNumber());
+
+        $actualRow = $reader->getRow();
+        $this->assertEquals($secondMetaRow, $actualRow);
+        $this->assertEquals(2, $reader->getLineNumber());
 
         // give it the ol' one-two-switcharoo
         $reader->advanceTo(3);
-        $reader->getRow();
+        $advancedRow = $reader->getRow();
+
+        $this->assertEquals(
+            $this->headers,
+            $advancedRow
+        );
+
         $reader->advanceTo(0);
 
-        $this->assertEquals( $row, $reader->getRow() );
+        $this->assertEquals($firstMetaRow, $reader->getRow());
+        $this->assertEquals(1, $reader->getLineNumber());
+
+        $this->assertEquals($secondMetaRow, $reader->getRow());
+        $this->assertEquals(2, $reader->getLineNumber());
+
+        $reader->advanceTo(1);
+
+        $row = $reader->getRow();
+        $this->assertEquals(2, $reader->getLineNumber());
+        $this->assertEquals(
+            $secondMetaRow,
+            $row
+        );
+    }
+
+    /**
+     * @dataProvider getReaders
+     */
+    public function testAdvanceToLastLine(Reader $reader)
+    {
+        $reader->advanceTo(5);
+    }
+
+    /**
+     * @dataProvider getReadersNoHeadersFirstRow
+     * @expectedException \LogicException
+     */
+    public function testAdvanceToBeforeHeaderLineNoHeadersFirstRow(Reader $reader)
+    {
+        $reader->setHeaderLine(3);
+        $reader->advanceTo(1);
+    }
+
+    /**
+     * @dataProvider getReaders
+     * @expectedException \LogicException
+     */
+    public function testAdvanceToHeaderLine(Reader $reader)
+    {
+        $reader->getRow();
+        $reader->advanceTo(0);
+    }
+
+    /**
+     * @dataProvider getReaders
+     * @expectedException \LogicException
+     */
+    public function testAdvanceToPastEof(Reader $reader)
+    {
+        $reader->advanceTo(999);
     }
 
     /**
@@ -127,13 +247,13 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetHeaderLine(Reader $reader)
     {
-        $headers = $this->headerValues;
+        $headers = $this->headers;
 
-        $this->assertEquals( $headers, $reader->getHeaders() );
+        $this->assertEquals($headers, $reader->getHeaders());
 
         $reader->setHeaderLine(0);
 
-        $this->assertEquals( $headers, $reader->getHeaders() );
+        $this->assertEquals($headers, $reader->getHeaders());
     }
 
     /**
@@ -142,9 +262,9 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
     public function testSetHeaderLineNoHeadersFirstRow(Reader $reader)
     {
         // set headers
-        $reader->setHeaderLine( 3 );
+        $reader->setHeaderLine(3);
 
-        $this->assertEquals( $this->headerValues, $reader->getHeaders() );
+        $this->assertEquals($this->headers, $reader->getHeaders());
 
         $rows = $reader->getAll();
 
@@ -157,7 +277,8 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetLastLineNumber(Reader $reader)
     {
-        $this->assertEquals( 5, $reader->getLastLineNumber() );
+        $this->assertEquals(5, $reader->getLastLineNumber());
+        $this->assertEquals(5, $reader->getLastLineNumber());
     }
 
     /**
@@ -165,7 +286,7 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetLastLineNumberNoHeadersFirstRow(Reader $reader)
     {
-        $this->assertEquals( 10, $reader->getLastLineNumber() );
+        $this->assertEquals(10, $reader->getLastLineNumber());
     }
 
     public function getReaders()
@@ -181,11 +302,11 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
 
     public function getReadersNoHeadersFirstRow()
     {
-        $readerSemiColon = new Reader(__DIR__ . '/read_header_line_sc.csv', 'r+', false );
+        $readerSemiColon = new Reader(__DIR__ . '/read_header_line_sc.csv', 'r+', false);
         $readerSemiColon->setDelimiter(';');
 
         return array(
-            array(new Reader(__DIR__ . '/read_header_line.csv', 'r+', false )),
+            array(new Reader(__DIR__ . '/read_header_line.csv', 'r+', false)),
             array($readerSemiColon),
         );
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,7 @@
 
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 
-call_user_func(function() {
+call_user_func(function () {
     $loader = new \Composer\Autoload\ClassLoader();
     $loader->add('EasyCSV\Test', __DIR__);
     $loader->register();


### PR DESCRIPTION
discovered SplFileObject::fgetcsv() bugs implemented a workaround in the meantime, removed superfluous $line, more unit tests, updated README with examples

To care in code formatting. Hopefully I caught everything ahead of time.

After some more tests I discovered a few different SplFileObject::fgetcsv() bugs. I guess not a lot of people use it as they probably would've found the bugs a long time ago. As far as I can see PHP 5.5.15 and 5.4.31 are affected.

Here's my test case to show the bugs

```php
<?php

class CSV {
    protected $delimiter = ',';
    protected $enclosure = '"';

    public function __construct($path, $mode = 'r+')
    {
        $this->handle = new \SplFileObject($path, $mode);
        $this->handle->setFlags(\SplFileObject::DROP_NEW_LINE);
    }

    public function getFile()
    {
        return $this->handle;
    }

    public function getRow()
    {
        if ($this->isEof() === true) {
            return false;
        }

        $row = $this->handle->fgetcsv($this->delimiter, $this->enclosure);

        return $row;
    }

    public function getAll()
    {
        $data = array();
        while ($row = $this->getRow()) {
            $data[] = $row;
        }
        return $data;
    }

    public function advanceTo($line)
    {
        $this->handle->seek($line);
    }

    public function getCurrentLine()
    {
        return $this->handle->current();
    }

    public function getLineNumber()
    {
        return $this->handle->key();
    }

    public function rewind(){
        $this->handle->rewind();
    }

    /**
     * @return bool
     */
    protected function isEof()
    {
        return $this->handle->eof();
    }
}

/**
 * Class SplFileObjectTest
 *
 * Test to show unwanted behavior when \SplFileObject::READ_AHEAD is set.
 *
 */
class SplFileObjectTest extends PHPUnit_Framework_TestCase {

    protected $headers = array('column1', 'column2', 'column3');

    protected $dataRow1 = array(
        '1column2value',
        '1column3value',
        '1column4value',
    );

    /**
     * @var CSV
     */
    protected $csv;

    public function setUp()
    {
        $this->csv = new CSV(__DIR__ . '/read.csv');
    }

    /**
     * No calls to current(), seek(), or rewind()
     */
    public function testCaseThatWorks()
    {
        $rows = $this->csv->getAll();
        $this->assertCount(6, $rows);
        $this->assertEquals($this->headers, $rows[0]);
    }

    public function testWithoutCurrentCall()
    {
        $row = $this->csv->getRow();

        $this->assertEquals($this->headers, $row);
    }

    public function testSeek()
    {
        $this->csv->advanceTo(0);

        $row = $this->csv->getRow();

        $this->assertEquals($this->headers, $row);
        $this->assertEquals(0, $this->csv->getLineNumber());

        $row = $this->csv->getRow();
        $this->assertEquals(1, $this->csv->getLineNumber());

        $this->assertEquals($this->dataRow1, $row);

        $this->csv->advanceTo(1);

        $row = $this->csv->getRow();

        // for some reason it's getting line 3 instead of line 2
        $this->assertEquals($this->dataRow1, $row);
        $this->assertEquals(1, $this->csv->getLineNumber());
    }

    public function testRewind()
    {
        $this->assertEquals(0, $this->csv->getLineNumber());
        $this->csv->rewind();

        $row = $this->csv->getRow();
        $this->assertEquals(0, $this->csv->getLineNumber());

        $this->assertEquals($this->headers, $row);
    }

    public function testCurrent()
    {
        $this->assertEquals(0, $this->csv->getLineNumber());
        // if we make a call to SplFileObject::current() for some reason it advances one line?
        // if we don't call it before the SplFileObject::fgetcsv() call, we get the right row
        $this->csv->getCurrentLine();

        $row = $this->csv->getRow();
        $this->assertEquals(0, $this->csv->getLineNumber());

        $this->assertEquals($this->headers, $row);
    }

    public function testGetRowsOneByOne()
    {
        $this->csv->getRow();
        $this->csv->getRow();
        $this->csv->getRow();
        $this->csv->getRow();
        $this->csv->getRow();
        $row = $this->csv->getRow();

        $expected = array(
            0 => '5column2value',
            1 => '5column3value',
            2 => '5column4value',
        );

        $this->assertEquals($expected, $row);
        $this->assertEquals(5, $this->csv->getLineNumber());
    }
}

```